### PR TITLE
Add .decode() method handling chars split across chunks

### DIFF
--- a/datastream.py
+++ b/datastream.py
@@ -246,5 +246,6 @@ class DataStream():
     def decode(self, encoding):
         import codecs
         # Incremental decoders handle characters split across inputs.
+        # Input with only partial data yields empty string - drop these.
         decoder = codecs.getincrementaldecoder(encoding)()
-        return self.map(lambda chunk: decoder.decode(chunk))
+        return self.map(lambda chunk: decoder.decode(chunk) or DropChunk)

--- a/test/test_miscellaneous.py
+++ b/test/test_miscellaneous.py
@@ -1,10 +1,9 @@
 from datastream import DataStream
 import pytest
 
-@pytest.mark.asyncio
-async def test_decoding_characters_split_across_chunks():
+async def read_as_binary_and_decode(size, expected):
     with open('sample_multibyte_text.txt', 'rb') as file:
-        bytes = await DataStream.read_from(file, chunk_size=1).to_list()
+        bytes = await DataStream.read_from(file, chunk_size=size).to_list()
 
         # ensure that we really have characters split across chunks
         with pytest.raises(UnicodeDecodeError):
@@ -12,4 +11,14 @@ async def test_decoding_characters_split_across_chunks():
                 chunk.decode("UTF-8")
 
         result = await DataStream.read_from(bytes).decode("UTF-8").to_list()
-        assert result == ['', 'ż', '', 'ó', '', 'ł', '', 'ć']
+        assert result == expected
+
+@pytest.mark.asyncio
+async def test_decoding_characters_split_across_chunks():
+    await read_as_binary_and_decode(3, ['ż', 'ół', 'ć'])
+
+@pytest.mark.asyncio
+async def test_decoding_chunks_with_():
+    # with chunk_size == 1 some incoming chunks will contain only partial
+    # data, yielding empty strings. Ensure these are dropped.
+    await read_as_binary_and_decode(1, ['ż', 'ó', 'ł', 'ć'])


### PR DESCRIPTION
Quite straightforward. This will be useful for testing stream conversions (e.g. datastream -> stringstream).