### PR TITLE
String stream stub

### DIFF
--- a/test/test_miscellaneous.py
+++ b/test/test_miscellaneous.py
@@ -1,4 +1,4 @@
-from scramjet.datastream import DataStream
+from scramjet.datastream import DataStream, StringStream
 import pytest
 
 async def read_as_binary_and_decode(size, expected):
@@ -22,3 +22,36 @@ async def test_decoding_chunks_with_():
     # with chunk_size == 1 some incoming chunks will contain only partial
     # data, yielding empty strings. Ensure these are dropped.
     await read_as_binary_and_decode(1, ['ż', 'ó', 'ł', 'ć'])
+
+@pytest.mark.asyncio
+async def test_read_from_respects_stream_class():
+    stream = StringStream.read_from(['a', 'b', 'c', 'd'])
+    assert type(stream) == StringStream
+
+@pytest.mark.asyncio
+async def test_changing_datastream_to_stringstream():
+    s1 = DataStream.read_from(['a', 'b', 'c', 'd'])
+    s2 = s1._as(StringStream)
+    assert type(s2) == StringStream
+    assert type(s1) == DataStream
+    assert await s2.to_list() == ['a', 'b', 'c', 'd']
+
+@pytest.mark.asyncio
+async def test_mapping_stringstream_produces_stringstream():
+    s1 = StringStream.read_from(['a', 'b', 'c', 'd'])
+    s2 = s1.map(lambda s: s*2)
+    assert type(s1) == type(s2) == StringStream
+    assert await s2.to_list() == ['aa', 'bb', 'cc', 'dd']
+
+@pytest.mark.asyncio
+async def test_decoding_datastream_produces_stringstream():
+    s1 = DataStream.read_from([b'foo\n', b'bar baz\n', b'qux'])
+    s2 = s1.decode("UTF-8")
+    assert type(s2) == StringStream
+    assert await s2.to_list() == ['foo\n', 'bar baz\n', 'qux']
+
+@pytest.mark.asyncio
+async def test_converting_streams_does_not_break_pyfca():
+    s1 = DataStream.read_from(['a', 'b', 'c', 'd']).map(lambda x: x*2)
+    s2 = s1._as(StringStream).map(lambda x: 'foo '+x)
+    assert s2.pyfca == s1.pyfca


### PR DESCRIPTION
No functionality yet, but ensure that all stream methods will use
correct class depending on whether they were called on StringStream or
DataStream. Add a method for casting one type of stream to another; it
reuses pyfca from the original stream so there should be no unwanted
side effects.