### PR TITLE
Add .write_to() method (supporting files and streams)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Transform a stream:
 Collect data from the stream (asynchronous):
 
 * `to_list` - return a list with all stream chunks.
+* `write_to` - write all resulting stream chunks into a target.
 * `reduce` - combine all chunks using specified function.
 
 

--- a/scramjet/streams.py
+++ b/scramjet/streams.py
@@ -349,6 +349,25 @@ class DataStream():
         return result
 
 
+    async def write_to(self, target):
+        """
+        Write all resulting stream chunks into target.
+
+        target: object implementing .write() method
+        """
+        self._mark_consumed()
+        self._uncork()
+        log(self, f'sink: {repr(target)}')
+        chunk = await self._pyfca.read()
+        while chunk is not None:
+            log(self, f'got: {tr(chunk)}')
+            write = target.write(chunk)
+            if asyncio.iscoroutine(write):
+                await write
+            chunk = await self._pyfca.read()
+        return target
+
+
     async def reduce(self, func, initial=None):
         """
         Apply two-argument func to elements from the stream cumulatively,

--- a/test/test_datastream_buffering.py
+++ b/test/test_datastream_buffering.py
@@ -15,7 +15,6 @@ async def echo(x):
 async def test_reading_and_writing_to_file():
     with open('test/sample_text_1.txt') as file_in, \
          open('test_output', 'w') as file_out:
-        async for item in DataStream.read_from(file_in):
-            file_out.write(item)
+        await DataStream.read_from(file_in).write_to(file_out)
     with open('test/sample_text_1.txt') as source, open('test_output') as dest:
         assert source.read() == dest.read()

--- a/test/test_write_to.py
+++ b/test/test_write_to.py
@@ -1,0 +1,18 @@
+from scramjet.streams import DataStream
+import pytest
+
+@pytest.mark.asyncio
+async def test_write_to_file():
+    with open("test_output", 'w') as file:
+        s = DataStream.read_from("abcdef")
+        await s.write_to(file)
+    with open("test_output") as file:
+        assert file.read() == "abcdef"
+
+@pytest.mark.asyncio
+async def test_write_to_another_stream():
+    s1 = DataStream.read_from(range(8), max_parallel=4).map(lambda x: x+1)
+    s2 = DataStream(name="s2", max_parallel=4)
+    await s1.write_to(s2)
+    s2.end()
+    assert await s2.to_list() == [1, 2, 3, 4, 5, 6, 7, 8]


### PR DESCRIPTION
Quite straightforward. This is supposed to be The method for getting stuff from scramjet stream into another stream-like object.